### PR TITLE
Remove windows.h from the platform.h

### DIFF
--- a/cpp_common/include/ros/platform.h
+++ b/cpp_common/include/ros/platform.h
@@ -31,35 +31,10 @@
 #define CPP_COMMON_PLATFORM_H_
 
 /******************************************************************************
-* Includes
-******************************************************************************/
-
-#ifdef WIN32
-  #ifdef _MSC_VER
-    #ifndef WIN32_LEAN_AND_MEAN
-      #define WIN32_LEAN_AND_MEAN // slimmer compile times
-    #endif
-
-    #ifndef _WINSOCKAPI_
-      #define _WINSOCKAPI_ // stops windows.h from including winsock.h (and lets us include winsock2.h)
-    #endif
-
-    #ifndef NOMINMAX
-      #define NOMINMAX // windows c++ pollutes the environment like any factory
-    #endif
-  #endif
-  #include <windows.h>
-#endif
-
-
-
-/******************************************************************************
 * Cross Platform Functions
 ******************************************************************************/
 
-#ifndef _MSC_VER
-  #include <stdlib.h> // getenv
-#endif
+#include <stdlib.h> // getenv, _dupenv_s
 #include <string>
 
 namespace ros {

--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -51,7 +51,7 @@
 #include <mach/mach.h>
 #endif  // defined(__APPLE__)
 
-#ifdef WIN32
+#ifdef _WINDOWS
 #include <windows.h>
 #endif
 

--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -51,6 +51,10 @@
 #include <mach/mach.h>
 #endif  // defined(__APPLE__)
 
+#ifdef WIN32
+#include <windows.h>
+#endif
+
 #include <boost/thread/mutex.hpp>
 #include <boost/io/ios_state.hpp>
 #include <boost/date_time/posix_time/ptime.hpp>


### PR DESCRIPTION
This is one of the PRs to remove Windows.h from ROS headers, and in turn we reduce the Windows namespace conflicts problems for many downstream packages.