### PR TITLE
use std::this_thread::sleep_for instead of WaitableTimer

### DIFF
--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -41,9 +41,11 @@
 #include "ros/impl/time.h"
 #include <cmath>
 #include <ctime>
+#include <chrono>
 #include <iomanip>
-#include <stdexcept>
 #include <limits>
+#include <stdexcept>
+#include <thread>
 
 // time related includes for macOS
 #if defined(__APPLE__)
@@ -232,27 +234,7 @@ namespace ros
   int ros_nanosleep(const uint32_t &sec, const uint32_t &nsec)
   {
 #if defined(WIN32)
-    HANDLE timer = NULL;
-    LARGE_INTEGER sleepTime;
-    sleepTime.QuadPart = -
-      static_cast<int64_t>(sec)*10000000LL -
-      static_cast<int64_t>(nsec) / 100LL;
-
-    timer = CreateWaitableTimer(NULL, TRUE, NULL);
-    if (timer == NULL)
-      {
-        return -1;
-      }
-
-    if (!SetWaitableTimer (timer, &sleepTime, 0, NULL, NULL, 0))
-      {
-        return -1;
-      }
-
-    if (WaitForSingleObject (timer, INFINITE) != WAIT_OBJECT_0)
-      {
-        return -1;
-      }
+    std::this_thread::sleep_for(std::chrono::nanoseconds(static_cast<int64_t>(sec * 1e9 + nsec)));
     return 0;
 #else
     timespec req = { sec, nsec };


### PR DESCRIPTION
test cases in the `rostime` package sometimes fail with errors like this:
```
[ RUN      ] Duration.sleepWithSignal
D:\a\1\a\_ws\src\roscpp_core\rostime\test\time.cpp(528): error: Expected: (end - start) > (d), actual: 1.999883400 vs 2.000000000
```
the reason behind is that all the test cases that are failing like this are testing the `Duration::sleep` method, and that method calls into `ros_nanosleep` through `ros_wallsleep` internally. inside `ros_nanosleep`, `SetWaitableTimer` and `WaitForSingleObject` are used as an alternative to `nanosleep` on Linux. however, based on our testing, this pair of function tend to have accuracy errors.

in this pr, we propose to use `std::this_thread::sleep_for` (introduced in C++11) instead. functionally, it is essentially the same: blocks the current thread until a certain amount of time has elapsed. one thing to note is that this method does not seem to support waking up the thread by signal; however, signal is not supported by the use of `SetWaitableTimer` and `WaitForSingleObject` either, so this should not be a problem. still, to minimize the impact of this change, this is scoped to `WIN32` only