### PR TITLE
ROS::Time Windows impl not millisecond sensitive

### DIFF
--- a/rostime/src/time.cpp
+++ b/rostime/src/time.cpp
@@ -120,63 +120,14 @@ namespace ros
     nsec = timeofday.tv_usec * 1000;
 #endif
 #else
-    // Win32 implementation
-    // unless I've missed something obvious, the only way to get high-precision
-    // time on Windows is via the QueryPerformanceCounter() call. However,
-    // this is somewhat problematic in Windows XP on some processors, especially
-    // AMD, because the Windows implementation can freak out when the CPU clocks
-    // down to save power. Time can jump or even go backwards. Microsoft has
-    // fixed this bug for most systems now, but it can still show up if you have
-    // not installed the latest CPU drivers (an oxymoron). They fixed all these
-    // problems in Windows Vista, and this API is by far the most accurate that
-    // I know of in Windows, so I'll use it here despite all these caveats
-    static LARGE_INTEGER cpu_freq, init_cpu_time;
-    static uint32_t start_sec = 0;
-    static uint32_t start_nsec = 0;
-    if ( ( start_sec == 0 ) && ( start_nsec == 0 ) )
-      {
-        QueryPerformanceFrequency(&cpu_freq);
-        if (cpu_freq.QuadPart == 0) {
-          throw NoHighPerformanceTimersException();
-        }
-        QueryPerformanceCounter(&init_cpu_time);
-        // compute an offset from the Epoch using the lower-performance timer API
-        FILETIME ft;
-        GetSystemTimeAsFileTime(&ft);
-        LARGE_INTEGER start_li;
-        start_li.LowPart = ft.dwLowDateTime;
-        start_li.HighPart = ft.dwHighDateTime;
-        // why did they choose 1601 as the time zero, instead of 1970?
-        // there were no outstanding hard rock bands in 1601.
-#ifdef _MSC_VER
-    	start_li.QuadPart -= 116444736000000000Ui64;
-#else
-    	start_li.QuadPart -= 116444736000000000ULL;
-#endif
-        int64_t start_sec64 = start_li.QuadPart / 10000000;  // 100-ns units
-        if (start_sec64 < 0 || start_sec64 > std::numeric_limits<uint32_t>::max())
-          throw std::runtime_error("SystemTime is out of dual 32-bit range");
-        start_sec = (uint32_t)start_sec64;
-        start_nsec = (start_li.LowPart % 10000000) * 100;
-      }
-    LARGE_INTEGER cur_time;
-    QueryPerformanceCounter(&cur_time);
-    LARGE_INTEGER delta_cpu_time;
-    delta_cpu_time.QuadPart = cur_time.QuadPart - init_cpu_time.QuadPart;
-    // todo: how to handle cpu clock drift. not sure it's a big deal for us.
-    // also, think about clock wraparound. seems extremely unlikey, but possible
-    double d_delta_cpu_time = delta_cpu_time.QuadPart / (double) cpu_freq.QuadPart;
-    uint32_t delta_sec = (uint32_t) floor(d_delta_cpu_time);
-    uint32_t delta_nsec = (uint32_t) boost::math::round((d_delta_cpu_time-delta_sec) * 1e9);
+      auto n = std::chrono::system_clock::now();
+      uint64_t now_s = 0;
+      uint64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
 
-    int64_t sec_sum  = (int64_t)start_sec  + (int64_t)delta_sec;
-    int64_t nsec_sum = (int64_t)start_nsec + (int64_t)delta_nsec;
+      normalizeSecNSec(now_s, now_ns);
 
-    // Throws an exception if we go out of 32-bit range
-    normalizeSecNSecUnsigned(sec_sum, nsec_sum);
-
-    sec = sec_sum;
-    nsec = nsec_sum;
+      sec = (uint32_t)now_s;
+      nsec = (uint32_t)now_ns;
 #endif
   }
 
@@ -200,26 +151,14 @@ namespace ros
     sec  = start.tv_sec;
     nsec = start.tv_nsec;
 #else
-    static LARGE_INTEGER cpu_frequency, performance_count;
-    // These should not ever fail since XP is already end of life:
-    // From https://msdn.microsoft.com/en-us/library/windows/desktop/ms644905(v=vs.85).aspx and
-    //      https://msdn.microsoft.com/en-us/library/windows/desktop/ms644904(v=vs.85).aspx:
-    // "On systems that run Windows XP or later, the function will always succeed and will
-    //  thus never return zero."
-    QueryPerformanceFrequency(&cpu_frequency);
-    if (cpu_frequency.QuadPart == 0) {
-      throw NoHighPerformanceTimersException();
-    }
-    QueryPerformanceCounter(&performance_count);
-    double steady_time = performance_count.QuadPart / (double) cpu_frequency.QuadPart;
-    int64_t steady_sec = floor(steady_time);
-    int64_t steady_nsec = boost::math::round((steady_time - steady_sec) * 1e9);
+      auto n = std::chrono::steady_clock::now();
+      uint64_t now_s = 0;
+      uint64_t now_ns = std::chrono::duration_cast<std::chrono::nanoseconds>(std::chrono::steady_clock::now().time_since_epoch()).count();
 
-    // Throws an exception if we go out of 32-bit range
-    normalizeSecNSecUnsigned(steady_sec, steady_nsec);
+      normalizeSecNSec(now_s, now_ns);
 
-    sec = steady_sec;
-    nsec = steady_nsec;
+      sec = (uint32_t)now_s;
+      nsec = (uint32_t)now_ns;
 #endif
   }
 


### PR DESCRIPTION
The custom Win32 time solution implemented in ros::Time results in pathological cases which cause periodic timers to fire in extremely large periods - 33ms timers fire can fire up to 1.5 seconds late. To address this, we've simplified the codebase to use std::chrono which is nanosecond sensitive internally, which improves the downstream reliability and repeatability of timers. 